### PR TITLE
fix english spelling of the word 'completed'

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -2,10 +2,10 @@
 # Copyright (C) 2023 Tim Lauridsen
 # This file is distributed under the GNU GPLv3 license.
 # Tim Lauridsen, 2023.
-# 
+#
 # Translators:
 # Davidmp <medipas@gmail.com>, 2023
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
@@ -127,7 +127,7 @@ msgid "Running Flatpak Transaction"
 msgstr "Execució de la transacció de Flatpak"
 
 #: yumex/ui/window.py:264
-msgid "Transaction completted succesfully"
+msgid "Transaction completed succesfully"
 msgstr "Transacció completada correctament"
 
 #: yumex/backend/dnf/dnf4.py:121

--- a/po/da.po
+++ b/po/da.po
@@ -2,10 +2,10 @@
 # Copyright (C) 2023 Tim Lauridsen
 # This file is distributed under the GNU GPLv3 license.
 # Tim Lauridsen, 2023.
-# 
+#
 # Translators:
 # Tim Lauridsen <tla@rasmil.dk>, 2022
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
@@ -127,7 +127,7 @@ msgid "Running Flatpak Transaction"
 msgstr ""
 
 #: yumex/ui/window.py:264
-msgid "Transaction completted succesfully"
+msgid "Transaction completed succesfully"
 msgstr ""
 
 #: yumex/backend/dnf/dnf4.py:121

--- a/po/it.po
+++ b/po/it.po
@@ -127,7 +127,7 @@ msgid "Running Flatpak Transaction"
 msgstr "Eseguendo Transazione Flatpak"
 
 #: yumex/ui/window.py:264
-msgid "Transaction completted succesfully"
+msgid "Transaction completed succesfully"
 msgstr "Transazione completata con successo"
 
 #: yumex/backend/dnf/dnf4.py:121

--- a/po/yumex.pot
+++ b/po/yumex.pot
@@ -136,7 +136,7 @@ msgid "Running Flatpak Transaction"
 msgstr ""
 
 #: yumex/ui/window.py:284
-msgid "Transaction completted succesfully"
+msgid "Transaction completed succesfully"
 msgstr ""
 
 #: yumex/backend/dnf/dnf4.py:121

--- a/yumex/backend/dnf/dnf4.py
+++ b/yumex/backend/dnf/dnf4.py
@@ -505,7 +505,7 @@ class Backend(DnfBase):
                 log(f" DNF4: dnf package for {pkg} was not found")
         try:
             res = self.resolve(allow_erasing=True)
-            log(f" DNF4: depsolve completted : {res}")
+            log(f" DNF4: depsolve completed : {res}")
             for pkg in self.get_transaction():
                 if pkg.nevra not in nevra_dict:
                     log(f" DNF4: adding as dep : {pkg} ")

--- a/yumex/backend/dnf/dnf5.py
+++ b/yumex/backend/dnf/dnf5.py
@@ -234,7 +234,7 @@ class Backend(dnf.Base):
                     log(f" DNF5: add {nevra} to transaction for installation")
         transaction: dnf.Transaction = goal.resolve()
         problems = transaction.get_problems()
-        log(f" DNF5: depsolve completted : {problems}")
+        log(f" DNF5: depsolve completed : {problems}")
         if problems == dnf.GoalProblem_NO_PROBLEM:
             for tspkg in transaction.get_transaction_packages():
                 action = tspkg.get_action()

--- a/yumex/backend/dnf5daemon/__init__.py
+++ b/yumex/backend/dnf5daemon/__init__.py
@@ -62,7 +62,7 @@ class DownloadQueue:
             return 0.0
 
     @property
-    def is_completted(self):
+    def is_completed(self):
         return self.current == self.total
 
     def add(self, pkg):
@@ -224,7 +224,7 @@ class YumexRootBackend:
             match pkg.package_type:
                 case DownloadType.PACKAGE:
                     pkg.downloaded = pkg.to_download
-                    if self.download_queue.is_completted:
+                    if self.download_queue.is_completed:
                         self.progress.set_title(_("Applying Transaction"))
                 case DownloadType.REPO:
                     pkg.downloaded = 1

--- a/yumex/ui/window.py
+++ b/yumex/ui/window.py
@@ -281,7 +281,7 @@ class YumexMainWindow(Adw.ApplicationWindow):
                 # reset everything
                 self.package_view.reset()
                 self.search_bar.set_search_mode(False)
-                self.show_message(_("Transaction completted succesfully"), timeout=3)
+                self.show_message(_("Transaction completed succesfully"), timeout=3)
                 self.package_settings.unselect_all()
                 self.select_page(Page.PACKAGES)
                 self.load_packages(PackageFilter.INSTALLED)


### PR DESCRIPTION
This was pointed out by someone in my discord channel -- the word 'completed' is misspelled throughout the project:
```
./po/it.po:130:msgid "Transaction completted succesfully"
./po/ca.po:130:msgid "Transaction completted succesfully"
./po/da.po:130:msgid "Transaction completted succesfully"
./po/yumex.pot:139:msgid "Transaction completted succesfully"
./yumex/ui/window.py:284:                self.show_message(_("Transaction completted succesfully"), timeout=3)
./yumex/backend/dnf5daemon/__init__.py:65:    def is_completted(self):
./yumex/backend/dnf5daemon/__init__.py:227:                    if self.download_queue.is_completted:
./yumex/backend/dnf/dnf5.py:237:        log(f" DNF5: depsolve completted : {problems}")
./yumex/backend/dnf/dnf4.py:508:            log(f" DNF4: depsolve completted : {res}")
```

https://www.dictionary.com/browse/completed

```
verb (used with object),com·plet·ed, com·plet·ing.
```