### PR TITLE
Force user cache directory for DNF5, get user cache directory from api instead of hardcode.

### DIFF
--- a/yumex/backend/dnf/dnf4.py
+++ b/yumex/backend/dnf/dnf4.py
@@ -26,7 +26,6 @@ import itertools
 import shutil
 import glob
 import os
-import getpass
 
 from yumex.utils import log
 from yumex.utils.enums import (
@@ -442,10 +441,11 @@ class Backend(DnfBase):
         self.setup_base()
 
     def dnf_temp_cleanup(self):
-        # Get the current user's username
-        username = getpass.getuser()
+        # Access the cache directory setting
+        cache_directory = self.conf.cachedir
+        print(cache_directory)
         # Construct the pattern with the username
-        pattern = f"/var/tmp/dnf-{username}*"
+        pattern = f"{cache_directory}/*"
         # List all directories matching the pattern
         directories = glob.glob(pattern)
         for directory in directories:

--- a/yumex/backend/dnf/dnf5.py
+++ b/yumex/backend/dnf/dnf5.py
@@ -16,7 +16,6 @@
 import shutil
 import glob
 import os
-import getpass
 
 from typing import Iterable, List
 
@@ -173,10 +172,10 @@ class Backend(dnf.Base):
         return self._get_yumex_packages(qa)
 
     def dnf_temp_cleanup(self):
-        # Get the current user's username
-        username = getpass.getuser()
+        # Access the cache directory setting
+        cache_directory = self.get_config().get_cachedir_option().get_value()
         # Construct the pattern with the username
-        pattern = f"/var/tmp/dnf-{username}*"
+        pattern = f"{cache_directory}/*"
         # List all directories matching the pattern
         directories = glob.glob(pattern)
         for directory in directories:

--- a/yumex/backend/dnf/dnf5.py
+++ b/yumex/backend/dnf/dnf5.py
@@ -88,6 +88,13 @@ class UpdateInfo:
 class Backend(dnf.Base):
     def __init__(self, presenter: Presenter, *args) -> None:
         super().__init__(*args)
+
+        # Yumex is run as user, force it to use user cache instead of systems
+        # This allows it to refresh the metadata correctly.
+        # It already does the same thing in DNF4
+        cache_directory = self.get_config().get_cachedir_option().get_value()
+        self.get_config().get_system_cachedir_option().set(cache_directory)
+
         self.presenter: Presenter = presenter
         self.load_config()
         self.setup()


### PR DESCRIPTION
Cleans up recently added cache clean/metadata refresh before displaying updates.

fixes #57 

Here's what's going on with dnf5 and the metadata (and what this MR fixes)

Yumex is prioritizing /var/cache/libdnf5/ over the user cache, and cannot refresh the metadata there.

If /var/cache/libdnf5 is not empty, it will read from it, but it will not refresh any metadata, therefore if the folder is not empty and new updates are added to a repo, it never gets refreshed.

If you manually remove the cache at /var/cache/libdnf5 then run yumex, it will then refresh the user's dnf cache at ~/.cache/libdnf5/

If you restore /var/cache/libdnf5/ then open yumex again, it has the same problem, can read, can't refresh, ignores user ~/.cache/libdnf5/

In this MR we make dnf5 think it's using the system cache by setting it to the user cache before loading the config in the Backend init:

https://github.com/timlau/yumex-ng/pull/63/files#diff-50c1419c10c1fe27ed5e3c9bfcfc2eaf308a9e34cc0ba7abae55d723f2e4b24fR95

