### PR TITLE
External app fixup

### DIFF
--- a/yumex/backend/dnf/dnf4.py
+++ b/yumex/backend/dnf/dnf4.py
@@ -35,7 +35,7 @@ from yumex.utils.enums import (
     InfoType,
     PackageFilter,
 )
-from yumex.backend.dnf import YumexPackage, reload_metadata_expired
+from yumex.backend.dnf import YumexPackage, reload_metadata_expired, update_metadata_timestamp
 
 
 def create_package(pkg, state=PackageState.AVAILABLE, action=PackageAction.NONE) -> YumexPackage:

--- a/yumex/service/data.py
+++ b/yumex/service/data.py
@@ -100,7 +100,8 @@ class Indicator:
 
     def on_clicked_custom(self, *args) -> None:
         """start custom updater"""
-        subprocess.Popen([self.custom_updater], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.Popen([self.custom_updater], shell=True)
+
 
     def on_clicked_pm(self, *args) -> None:
         """start yumex"""


### PR DESCRIPTION
The custom updater app we use in nobara wasn't launching, I had to dig around a bit to figure out it needed the shell option. Also we allow stderr/stdout so we can see in case the command fails.