### PR TITLE
don't force display and xauth envvars in user service, and pass exist…

### DIFF
--- a/data/service/yumex-updater-systray.service
+++ b/data/service/yumex-updater-systray.service
@@ -8,8 +8,6 @@ Type=simple
 ExecStart=/usr/bin/yumex_updater_systray
 RestartSec=5
 Restart=on-failure
-Environment=DISPLAY=:0
-Environment=XAUTHORITY=%h/.Xauthority
 
 [Install]
 WantedBy=graphical-session.target

--- a/yumex/service/data.py
+++ b/yumex/service/data.py
@@ -24,6 +24,7 @@ import configparser
 import shutil
 import logging
 import subprocess
+import os
 
 from pathlib import Path
 from dataclasses import dataclass
@@ -43,7 +44,8 @@ logger = logging.getLogger("yumex_updater")
 def open_yumex(*args):
     """launch yumex"""
     logger.info(f"open_yumex {args}")
-    subprocess.Popen(["/usr/bin/yumex", "--update"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    env = os.environ.copy()
+    subprocess.Popen(["/usr/bin/yumex", "--update"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
 
 
 @dataclass
@@ -100,7 +102,9 @@ class Indicator:
 
     def on_clicked_custom(self, *args) -> None:
         """start custom updater"""
-        subprocess.Popen([self.custom_updater], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        env = os.environ.copy()
+        custom_updater_args = self.custom_updater.split()
+        subprocess.Popen(custom_updater_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
 
     def on_clicked_pm(self, *args) -> None:
         """start yumex"""


### PR DESCRIPTION
…ing envvars when running subprocess popen. Also properly split custom application command into array for popen.

This allows applications which may need to run pkexec to run properly. For example Nobara's custom updater detects if pkexec or sudo has not been run (ie if it was run as a normal user) then  sudo  or pkexec's itself to run as root for update permissions. Since the service unit was forcing invalid xauthority settings it would not let any subprocesses pkexec.